### PR TITLE
Jcn 420 extensive payload by s3

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -39,7 +39,7 @@ module.exports = class Handler {
 
 		try {
 
-			const data = body?.contentS3Path ? await Lambda.getBodyFromS3(body?.contentS3Path) : body;
+			const data = body?.contentS3Path ? await Lambda.getBodyFromS3(body.contentS3Path) : body;
 
 			const dispatcher = new Dispatcher(LambdaFunction, session, data, taskToken);
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -4,6 +4,8 @@ const Events = require('@janiscommerce/events');
 
 const Dispatcher = require('./helpers/dispatcher');
 const setEnvVar = require('./helpers/set-env-var');
+const Lambda = require('./lambda-bases/lambda');
+const StepFunction = require('./step-function');
 
 /**
  * @typedef {import('./lambda-bases/lambda')} Lambda
@@ -31,10 +33,13 @@ module.exports = class Handler {
 		const {
 			taskToken,
 			session,
-			body: data
+			body,
+			stateMachine
 		} = event;
 
 		try {
+
+			const data = body?.contentS3Path ? await Lambda.getBodyFromS3(body?.contentS3Path) : body;
 
 			const dispatcher = new Dispatcher(LambdaFunction, session, data, taskToken);
 
@@ -47,6 +52,11 @@ module.exports = class Handler {
 			const result = await dispatcher.process();
 
 			this.emitEnded();
+
+			if(!stateMachine || !StepFunction.dataExceedsLimit(result?.data))
+				return result;
+
+			result.data = await Lambda.bodyToS3Path('step-function-payloads', result.data, dispatcher.payloadFixedProperties);
 
 			return result;
 

--- a/lib/helpers/dispatcher.js
+++ b/lib/helpers/dispatcher.js
@@ -31,6 +31,13 @@ module.exports = class Dispatcher {
 	}
 
 	/**
+	 * Get fields that should not be eliminated from the result
+	 */
+	get payloadFixedProperties() {
+		return this.lambdaFunction.payloadFixedProperties || [];
+	}
+
+	/**
 	 * @private
 	 */
 	validateLambdaFunction(LambdaFunction) {

--- a/lib/lambda-bases/lambda.js
+++ b/lib/lambda-bases/lambda.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const s3 = require('@janiscommerce/s3');
+const { customAlphabet } = require('nanoid');
+const lodashPick = require('lodash.pick');
+
+const NANOID_LENGTH = 10;
+const nanoid = customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789', NANOID_LENGTH);
+
 module.exports = class Lambda {
 
 	/**
@@ -87,6 +94,37 @@ module.exports = class Lambda {
 	 */
 	async process() {
 		return null;
+	}
+
+	static async bodyToS3Path(mainFolder, data, fixedProperties) {
+
+		if(!process.env.S3_BUCKET)
+			return data;
+
+		const now = new Date();
+
+		const key = `${mainFolder}/${now.getFullYear()}/${now.getMonth() + 1}/${now.getDate()}/${nanoid()}.json`;
+
+		await s3.putObject({
+			Body: JSON.stringify(data),
+			Bucket: process.env.S3_BUCKET,
+			Key: key
+		});
+
+		return {
+			contentS3Path: key,
+			...fixedProperties?.length && lodashPick(data, fixedProperties)
+		};
+	}
+
+	static async getBodyFromS3(bodyS3Key) {
+
+		const { Body } = await s3.getObject({
+			Bucket: process.env.S3_BUCKET,
+			Key: bodyS3Key
+		});
+
+		return JSON.parse(Body.toString());
 	}
 
 };

--- a/lib/step-function/index.js
+++ b/lib/step-function/index.js
@@ -3,6 +3,10 @@
 const StepFunctions = require('./wrapper');
 const StepFunctionsError = require('./error');
 
+const Lambda = require('../lambda-bases/lambda');
+
+const BYTE_DATA_LIMIT = 256000; // The real limit is 262144 bytes, but we use 256000 bytes to obtain a margin of bytes.
+
 /** @typedef {import('aws-sdk/clients/stepfunctions').Arn} ARN */
 
 /** @typedef {"RUNNING"|"SUCCEEDED"|"FAILED"|"TIMED_OUT"|"ABORTED"} ExecutionStatus */
@@ -18,9 +22,10 @@ module.exports = class StepFunction {
 	 * @param {string} [name] The name of the execution
 	 * @param {string} [clientCode] The client code
 	 * @param {*} [data] input data
+	 * @param {Array<string>} payloadFixedProperties the fields that should not be eliminated in the data
 	 * @return {object} The parameters.
 	 */
-	static getParams(arn, name, clientCode, data) {
+	static async getParams(arn, name, clientCode, data, payloadFixedProperties = []) {
 
 		if(!arn || typeof arn !== 'string' || !arn.length)
 			throw new StepFunctionsError('Arn cannot be empty and must be an string.', StepFunctionsError.codes.INVALID_ARN);
@@ -35,8 +40,12 @@ module.exports = class StepFunction {
 			throw new StepFunctionsError('Data must be an object.', StepFunctionsError.codes.INVALID_DATA);
 
 		const inputData = {
-			...(clientCode && { session: { clientCode } }),
-			...(data && { body: data })
+			session: clientCode ? { clientCode } : null,
+			...data && {
+				body: this.dataExceedsLimit(data)
+					? await Lambda.bodyToS3Path('step-function-payloads', data, payloadFixedProperties)
+					: data
+			}
 		};
 
 		return {
@@ -57,10 +66,11 @@ module.exports = class StepFunction {
 	 * @param {string} name The name of the execution
 	 * @param {string} clientCode The client code
 	 * @param {import('aws-sdk/clients/stepfunctions').StartExecutionInput} [data] input data
+	 * @param {Array<string>} payloadFixedProperties the fields that should not be eliminated in the data
 	 * @returns {Promise<import('aws-sdk/clients/stepfunctions').StartExecutionOutput>}
 	 */
-	static async startExecution(arn, name, clientCode, data) {
-		const params = this.getParams(arn, name, clientCode, data);
+	static async startExecution(arn, name, clientCode, data, payloadFixedProperties) {
+		const params = await this.getParams(arn, name, clientCode, data, payloadFixedProperties);
 		return StepFunctions.startExecution(params).promise();
 	}
 
@@ -97,10 +107,22 @@ module.exports = class StepFunction {
 	 * @returns {Promise<import('aws-sdk/clients/stepfunctions').ListExecutionsOutput>}
 	 */
 	static async listExecutions(arn, params) {
-		const stateMachineArn = this.getParams(arn);
+		const stateMachineArn = await this.getParams(arn);
 		return StepFunctions.listExecutions({
 			...stateMachineArn,
 			...params
 		}).promise();
+	}
+
+	/**
+	 * Check if the data exceeds the limit
+	 *
+	 * @param {*} [data] input data
+	 * {@link https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html#API_StartExecution_RequestSyntax AWS/LimitReference}
+	 *
+	 * @returns {Boolean} If the data exceeds the limit
+	 */
+	static dataExceedsLimit(data) {
+		return Buffer.byteLength(JSON.stringify(data)) >= BYTE_DATA_LIMIT;
 	}
 };

--- a/lib/step-function/index.js
+++ b/lib/step-function/index.js
@@ -39,13 +39,13 @@ module.exports = class StepFunction {
 		if((data && typeof data !== 'object') || Array.isArray(data))
 			throw new StepFunctionsError('Data must be an object.', StepFunctionsError.codes.INVALID_DATA);
 
+		const body = data && this.dataExceedsLimit(data)
+			? await Lambda.bodyToS3Path('step-function-payloads', data, payloadFixedProperties)
+			: data;
+
 		const inputData = {
 			session: clientCode ? { clientCode } : null,
-			...data && {
-				body: this.dataExceedsLimit(data)
-					? await Lambda.bodyToS3Path('step-function-payloads', data, payloadFixedProperties)
-					: data
-			}
+			body: body || null
 		};
 
 		return {

--- a/lib/step-function/index.js
+++ b/lib/step-function/index.js
@@ -51,7 +51,7 @@ module.exports = class StepFunction {
 		return {
 			stateMachineArn: arn,
 			...(name && { name }),
-			...(Object.keys(inputData).length && { input: JSON.stringify(inputData) })
+			input: JSON.stringify(inputData)
 		};
 	}
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "lllog": "^1.1.2",
     "lodash.pick": "^4.4.0",
     "lodash.startcase": "^4.4.0",
-    "nanoid": "^3.3.4",
-    "npm": "^9.2.0"
+    "nanoid": "^3.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,9 +42,14 @@
     "@janiscommerce/api-session": "^3.3.1",
     "@janiscommerce/aws-secrets-manager": "^0.2.1",
     "@janiscommerce/events": "^0.1.0",
+    "@janiscommerce/s3": "^1.5.1",
     "@janiscommerce/settings": "^1.0.1",
     "aws-sdk": "^2.1067.0",
+    "install": "^0.13.0",
     "lllog": "^1.1.2",
-    "lodash.startcase": "^4.4.0"
+    "lodash.pick": "^4.4.0",
+    "lodash.startcase": "^4.4.0",
+    "nanoid": "^3.3.4",
+    "npm": "^9.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@janiscommerce/s3": "^1.5.1",
     "@janiscommerce/settings": "^1.0.1",
     "aws-sdk": "^2.1067.0",
-    "install": "^0.13.0",
     "lllog": "^1.1.2",
     "lodash.pick": "^4.4.0",
     "lodash.startcase": "^4.4.0",

--- a/tests/handler.js
+++ b/tests/handler.js
@@ -343,7 +343,7 @@ describe('Handler', () => {
 			sinon.restore();
 		});
 
-		it('When the payload is extensive and the lambda is a step function', async () => {
+		it('When the payload is long and the lambda is running as a step function send the payload to an s3 and pass the URL in the body', async () => {
 
 			const body = {
 				name: 'Some-Name',

--- a/tests/lambda-bases/lambda.js
+++ b/tests/lambda-bases/lambda.js
@@ -74,7 +74,7 @@ describe('Lambda bases', () => {
 
 		it('Should not upload a file if the bucket variable does not exist', async () => {
 
-			sinon.spy(s3, 'putObject');
+			sinon.stub(s3, 'putObject');
 
 			Lambda.bodyToS3Path('folder-test', {});
 

--- a/tests/step-function/index.js
+++ b/tests/step-function/index.js
@@ -105,6 +105,21 @@ describe('StepFunctions tests', () => {
 			this.startExcecutionStub.returns({ promise: () => Promise.resolve(response) });
 
 			const result = await StepFunctions.startExecution('arn', null, null, null);
+
+			assert.deepEqual(result, response);
+		});
+
+		it('Should return data and always send input with session and body', async () => {
+
+			this.startExcecutionStub.returns({ promise: () => Promise.resolve(response) });
+
+			const result = await StepFunctions.startExecution('arn', null, null, null);
+
+			this.startExcecutionStub.calledOnceWithExactly({
+				stateMachineArn: 'arn',
+				input: '{"session":null,"body":null}'
+			});
+
 			assert.deepEqual(result, response);
 		});
 

--- a/tests/step-function/index.js
+++ b/tests/step-function/index.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
+const { Lambda } = require('../../lib');
 const StepFunctions = require('../../lib/step-function');
 const StepFunctionsWrapper = require('../../lib/step-function/wrapper');
 
@@ -104,6 +105,31 @@ describe('StepFunctions tests', () => {
 			this.startExcecutionStub.returns({ promise: () => Promise.resolve(response) });
 
 			const result = await StepFunctions.startExecution('arn', null, null, null);
+			assert.deepEqual(result, response);
+		});
+
+		it('Should return data response with a extensive payload', async () => {
+
+			this.startExcecutionStub.returns({ promise: () => Promise.resolve(response) });
+
+			const body = {
+				name: 'Some-Name',
+				age: 30,
+				numbers: []
+			};
+
+			for(let index = 100000; index < 130000; index++)
+				body.numbers.push(String(index));
+
+			const contentS3Path = 'step-function-payloads/2022/12/23/addasdsadas.json';
+
+			sinon.stub(Lambda, 'bodyToS3Path').resolves({
+				contentS3Path
+			});
+
+			const result = await StepFunctions.startExecution('arn', null, null, body);
+
+			sinon.assert.calledOnceWithExactly(Lambda.bodyToS3Path, 'step-function-payloads', body, []);
 			assert.deepEqual(result, response);
 		});
 


### PR DESCRIPTION
Este PR se complementa con el PR creado para el paquete de [sls-helper-plugin-janis](https://github.com/jormaechea/sls-helper-plugin-janis/pull/43)

Ticket: [JCN-420](https://fizzmod.atlassian.net/browse/JCN-420)

Debe cumplir con lo siguiente (sacado del ticket) 

Al ejecutar una step-function contemplar:

Si el body excede los 250KB y existe la variable de entorno S3_BUCKET se debe guardar en S3 y como dentro del body viajar el path, para luego descargarse.

Dar una posibilidad fijar campos, que no se borren a pesar de haber subido el body al S3, esto para seguir dando soporte a los Choice o Wait por ej.

El handler debe contemplar que el payload este en S3, y hay que bajar el JSON antes de avanzar al Dispatcher para que todo sea igual y transparente a las state-machine que hoy ya existen.

Al terminar una step-function (detectar con la nueva propiedad de 1)a)) se debe hacer el mismo proceso que 2)a)i).

Enviar siempre session, si no existe clientCode enviar null, ya que Parameters cuando no existe una propiedad da error no avanza.