### PR TITLE
result updated in lambda

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -53,10 +53,10 @@ module.exports = class Handler {
 
 			this.emitEnded();
 
-			if(!stateMachine || !StepFunction.dataExceedsLimit(result?.data))
+			if(!stateMachine || !StepFunction.dataExceedsLimit(result?.body))
 				return result;
 
-			result.data = await Lambda.bodyToS3Path('step-function-payloads', result.data, dispatcher.payloadFixedProperties);
+			result.body = await Lambda.bodyToS3Path('step-function-payloads', result.body, dispatcher.payloadFixedProperties);
 
 			return result;
 

--- a/lib/lambda-bases/lambda.js
+++ b/lib/lambda-bases/lambda.js
@@ -103,7 +103,13 @@ module.exports = class Lambda {
 
 		const now = new Date();
 
-		const key = `${mainFolder}/${now.getFullYear()}/${now.getMonth() + 1}/${now.getDate()}/${nanoid()}.json`;
+		const key = [
+			mainFolder,
+			now.getFullYear(),
+			String(now.getMonth() + 1).padStart(2, '0'),
+			String(now.getDate()).padStart(2, '0'),
+			`${nanoid()}.json`
+		].join('/');
 
 		await s3.putObject({
 			Body: JSON.stringify(data),

--- a/lib/step-function/index.js
+++ b/lib/step-function/index.js
@@ -123,6 +123,6 @@ module.exports = class StepFunction {
 	 * @returns {Boolean} If the data exceeds the limit
 	 */
 	static dataExceedsLimit(data) {
-		return Buffer.byteLength(JSON.stringify(data)) >= BYTE_DATA_LIMIT;
+		return data && Buffer.byteLength(JSON.stringify(data)) >= BYTE_DATA_LIMIT;
 	}
 };

--- a/tests/handler.js
+++ b/tests/handler.js
@@ -373,7 +373,7 @@ describe('Handler', () => {
 				process() {
 					return {
 						session: this.session,
-						data: this.data
+						body: this.data
 					};
 				}
 			}
@@ -381,7 +381,7 @@ describe('Handler', () => {
 			assert.deepStrictEqual(await Handler.handle(
 				LambdaFunctionExample,
 				{ session, body: { contentS3Path }, stateMachine }
-			), { session: apiSession, data: { contentS3Path } });
+			), { session: apiSession, body: { contentS3Path } });
 
 			sinon.assert.calledOnceWithExactly(Lambda.getBodyFromS3, contentS3Path);
 			sinon.assert.calledOnceWithExactly(Lambda.bodyToS3Path, 'step-function-payloads', body, []);


### PR DESCRIPTION
Actualice por pruebas en ambiente beta, que el package valida contra `.data` y es `.body` y por otro lado, vi que en el path de S3 viajan los números sin 0 a la izquierda y se los sume para que quede bien ordenado en el bucket