### PR TITLE
Jcn 420 extensive payload by s3

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -53,10 +53,16 @@ module.exports = class Handler {
 
 			this.emitEnded();
 
-			if(!stateMachine || !StepFunction.dataExceedsLimit(result?.body))
+			if(!stateMachine)
 				return result;
 
-			result.body = await Lambda.bodyToS3Path('step-function-payloads', result.body, dispatcher.payloadFixedProperties);
+			if(StepFunction.dataExceedsLimit(result?.body))
+				result.body = await Lambda.bodyToS3Path('step-function-payloads', result.body, dispatcher.payloadFixedProperties);
+
+			['body', 'session'].forEach(defaultField => {
+				if(result[defaultField] === undefined)
+					result[defaultField] = null;
+			});
 
 			return result;
 

--- a/tests/handler.js
+++ b/tests/handler.js
@@ -386,5 +386,24 @@ describe('Handler', () => {
 			sinon.assert.calledOnceWithExactly(Lambda.getBodyFromS3, contentS3Path);
 			sinon.assert.calledOnceWithExactly(Lambda.bodyToS3Path, 'step-function-payloads', body, []);
 		});
+
+		it('Should use a default value when the payload has no session or body and the lambda is executed as a step function', async () => {
+
+			const stateMachine = {
+				id: 'id-state-machine',
+				name: 'state-machine-test'
+			};
+			class LambdaFunctionExample {
+
+				process() {
+					return {};
+				}
+			}
+
+			assert.deepStrictEqual(await Handler.handle(
+				LambdaFunctionExample,
+				{ stateMachine }
+			), { session: null, body: null });
+		});
 	});
 });


### PR DESCRIPTION
Repasando el error que hubo en DevOps detecte que contemplamos body y session como null, al ejecutar una state, pero después en la medida que avanza en los pasos internos se puede borrar o perder, así que agregue que se contemple en pasos internos