### PR TITLE
Jcn 436 fix body error overwritten

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -87,7 +87,6 @@ module.exports = class Handler {
 		if(!body?.error)
 			return s3Body;
 
-		console.log('llegue')
 		return {
 			...s3Body,
 			error: body.error

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -77,8 +77,21 @@ module.exports = class Handler {
 		}
 	}
 
-	static getFullData(body) {
-		return body?.contentS3Path ? Lambda.getBodyFromS3(body.contentS3Path) : body;
+	static async getFullData(body) {
+
+		if(!body?.contentS3Path)
+			return body;
+
+		const s3Body = await Lambda.getBodyFromS3(body.contentS3Path);
+
+		if(!body?.error)
+			return s3Body;
+
+		console.log('llegue')
+		return {
+			...s3Body,
+			error: body.error
+		};
 	}
 
 	static async emitEnded() {

--- a/lib/parallel-handler.js
+++ b/lib/parallel-handler.js
@@ -13,10 +13,10 @@ module.exports = class ParallelHandler extends Handler {
 	static prepareEvent(event) {
 		return event.reduce((preparedEvent, { body, session, stateMachine }) => {
 
-			if (session && !preparedEvent.session)
+			if(session && !preparedEvent.session)
 				preparedEvent.session = session;
 
-			if (stateMachine && !preparedEvent.stateMachine)
+			if(stateMachine && !preparedEvent.stateMachine)
 				preparedEvent.stateMachine = stateMachine;
 
 			preparedEvent.body.push(body);
@@ -29,7 +29,7 @@ module.exports = class ParallelHandler extends Handler {
 
 	static getFullData(body) {
 
-		return Promise.all(body.map(async (item, index) => {
+		return Promise.all(body.map(async item => {
 
 			if(!item?.contentS3Path)
 				return item;

--- a/lib/parallel-handler.js
+++ b/lib/parallel-handler.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Handler = require('./handler');
-const Lambda = require('./lambda-bases/lambda');
 
 module.exports = class ParallelHandler extends Handler {
 
@@ -28,21 +27,6 @@ module.exports = class ParallelHandler extends Handler {
 	}
 
 	static getFullData(body) {
-
-		return Promise.all(body.map(async item => {
-
-			if(!item?.contentS3Path)
-				return item;
-
-			const s3Body = await Lambda.getBodyFromS3(item.contentS3Path);
-
-			if(!item?.error)
-				return s3Body;
-
-			return {
-				...s3Body,
-				error: item.error
-			};
-		}));
+		return Promise.all(body.map(super.getFullData));
 	}
 };

--- a/lib/parallel-handler.js
+++ b/lib/parallel-handler.js
@@ -13,10 +13,10 @@ module.exports = class ParallelHandler extends Handler {
 	static prepareEvent(event) {
 		return event.reduce((preparedEvent, { body, session, stateMachine }) => {
 
-			if(session && !preparedEvent.session)
+			if (session && !preparedEvent.session)
 				preparedEvent.session = session;
 
-			if(stateMachine && !preparedEvent.stateMachine)
+			if (stateMachine && !preparedEvent.stateMachine)
 				preparedEvent.stateMachine = stateMachine;
 
 			preparedEvent.body.push(body);
@@ -29,12 +29,20 @@ module.exports = class ParallelHandler extends Handler {
 
 	static getFullData(body) {
 
-		return Promise.all(body.map(item => {
+		return Promise.all(body.map(async (item, index) => {
 
 			if(!item?.contentS3Path)
 				return item;
 
-			return Lambda.getBodyFromS3(item.contentS3Path);
+			const s3Body = await Lambda.getBodyFromS3(item.contentS3Path);
+
+			if(!item?.error)
+				return s3Body;
+
+			return {
+				...s3Body,
+				error: item.error
+			};
 		}));
 	}
 };

--- a/tests/parallel-handler.js
+++ b/tests/parallel-handler.js
@@ -71,7 +71,8 @@ describe('ParallelHandler', () => {
 
 			const body3 = {
 				name: 'Long Body 1',
-				example: 'Imagine that this body weighs more than 250KB'
+				example: 'Imagine that this body weighs more than 250KB',
+				error: { Error: 'Lambda.Unknown' }
 			};
 
 			const body4 = {
@@ -80,7 +81,8 @@ describe('ParallelHandler', () => {
 			};
 
 			const bodyLong1 = {
-				contentS3Path: 'step-function-payloads/2023/01/01/bodyLong1.json'
+				contentS3Path: 'step-function-payloads/2023/01/01/bodyLong1.json',
+				error: { Error: 'Lambda.Unknown' }
 			};
 
 			const bodyLong2 = {
@@ -114,6 +116,7 @@ describe('ParallelHandler', () => {
 			class LambdaFunctionExample {
 
 				process() {
+
 					return {
 						session: this.session,
 						body: this.data


### PR DESCRIPTION
Link al ticket

[Historia](https://janiscommerce.atlassian.net/browse/JCN-435)

[Subtarea](https://janiscommerce.atlassian.net/browse/JCN-436)

### Descripción del requerimiento

#### Contexto

Cuando una Lambda es parte de una state machine y tiene un payload que supera al tamaño permitido por AWS, se sube la informacion a un bucket de S3 y se reemplaza esa informacion por la propiedad contentS3Path .

Al iniciar el step siguiente, desde el mismo paquete se valida si existe contentS3Path. Si existe, se descarga el contenido del S3 y se reemplaza el body con el cual se inicio la ejecución.

#### Problema

Cuando una ejecución falla por errores no controlados (como puede ser una lambda fallando por Timeout) y existe un step posterior para manejo de errores, si el payload es muy grande se da el siguiente escenario:

- Falla Lambda
- Redirige al Handle error con el ultimo payload del flujo mas la propiedad error con toda la info necesaria
- Inicia ejecución del Handle Error
  - El package encuentra la prop contentS3Path
  - Descarga el payload
  - Se pisa `this.data` con lo que había en S3, perdiendose la prop `this.data.error`
  - Rompe la ejecución del HandleError

![Screenshot(5)(1)](https://github.com/janis-commerce/lambda/assets/40437300/0fd637e8-8168-423a-b41e-bd5ff8432096)

![Screenshot(6)(1)](https://github.com/janis-commerce/lambda/assets/40437300/eb07ae74-4bbe-49eb-a956-5ce5ad9ae3a5)

### Descripción de la solución
Se modificaron los métodos `getFullData` para que al descargar un payload de S3 tambien incluya, si es que existe, el error recibido.

### Changelog

```
### Fixed
- ***Lambda*** and ***Parallel*** Handlers deleting received error data after downloading payload from S3
```