### PR TITLE
Get local port form Router

### DIFF
--- a/lib/helpers/get-local-service-port.js
+++ b/lib/helpers/get-local-service-port.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const RouterFetcher = require('@janiscommerce/router-fetcher');
+
+/**
+ * Get the local port of the service
+ * @param {string} serviceCode JANIS service code
+ * @returns {string}
+ */
+module.exports = async serviceCode => {
+
+	const routerFetcher = new RouterFetcher();
+	const { servers } = await routerFetcher.getSchema(serviceCode);
+
+	if(!servers)
+		return;
+
+	for(const server of servers) {
+		if(server.variables?.environment?.default === 'local')
+			return server.url.match(/(?<=:).+?(?=\/)/g)[1];
+	}
+};

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { ApiSession } = require('@janiscommerce/api-session');
-const Settings = require('@janiscommerce/settings');
 
 const LambdaError = require('./lambda-error');
 
@@ -14,6 +13,7 @@ const { isObjectNotEmpty } = require('./helpers/is-object');
 
 const isLocalEnv = require('./helpers/is-local-env');
 const getApiLambdaFunctionName = require('./helpers/get-api-lambda-function-name');
+const getLocalServicePort = require('./helpers/get-local-service-port');
 
 /**
  * @typedef InvokeResponse
@@ -37,18 +37,6 @@ module.exports = class Invoker {
 	 */
 	static get invocationType() {
 		return 'Event';
-	}
-
-	/**
-	 * @private
-	 * @static
-	 */
-	static get localServicePorts() {
-
-		if(!this._localServicePorts)
-			this._localServicePorts = Settings.get('localServicePorts') || {};
-
-		return this._localServicePorts;
 	}
 
 	/**
@@ -313,15 +301,15 @@ module.exports = class Invoker {
 		return serviceAccountId;
 	}
 
-	static getServiceLambdaInstance(serviceAccountId, serviceCode) {
+	static async getServiceLambdaInstance(serviceAccountId, serviceCode) {
 
 		if(!isLocalEnv())
 			return LambdaInstance.getInstanceWithRole(serviceAccountId);
 
-		const servicePort = this.localServicePorts[serviceCode];
+		const servicePort = await getLocalServicePort(serviceCode);
 
 		if(!servicePort)
-			throw new LambdaError(`No local service port found for service code ${serviceCode} in settings`, LambdaError.codes.NO_LOCAL_SERVICE_PORT);
+			throw new LambdaError(`No local service port found for service code ${serviceCode}`, LambdaError.codes.NO_LOCAL_SERVICE_PORT);
 
 		return LambdaInstance.getInstanceForLocalService(servicePort, serviceCode);
 

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "@janiscommerce/api-session": "^3.3.1",
     "@janiscommerce/aws-secrets-manager": "^1.0.2",
     "@janiscommerce/events": "^0.2.0",
+    "@janiscommerce/router-fetcher": "^2.1.2",
     "@janiscommerce/s3": "^2.0.0",
-    "@janiscommerce/settings": "^1.0.1",
     "lllog": "^1.1.2",
     "lodash": "^4.17.21",
     "nanoid": "^3.3.4"


### PR DESCRIPTION
Nueva forma de obtener el puerto del servicio en local para dejar de usar el localServicePorts en el archivo .janiscommercerc.json