### PR TITLE
Jcn 469 implement state event parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ The Lambda Function Class only needs to have a `process` method to execute. But 
 * Task token
     * `taskToken` (*getter*): the task token of a state machine. This will be only present when the function is invoked using the [callback service integration pattern](https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html#:~:text=the%20callback%20service%20integration%20pattern)
 
+* State
+    * `state` (*getter*): the state of a state machine task.
+
 * Validation stages
     * `mustHaveClient` (*getter*) : to check if the function received a client code in the session. **MUST** return `Boolean`. Default is false.
     * `mustHavePayload` (*getter*) : to check if the function received a body in the payload. **MUST** return `Boolean`. Default is false.
@@ -928,7 +931,7 @@ module.exports.handler = () => Handler.handle(StepExample, ...arguments);
 </details>
 
 
-##### :warning: IMPORTANT 
+##### :warning: IMPORTANT
 > If a task fails and you have defined a `HandleError` step that requires the error data to be available, unless the error is saved in `$.body.error`, the HandleError lambda function will download and overwrite the content from ***S3***. It is important to ensure that the `Catch[index].ResultPath` properties in your Tasks definition are set properly if you want to preserve all the data.
 
 ```json

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -34,14 +34,15 @@ module.exports = class Handler {
 			taskToken,
 			session,
 			body,
-			stateMachine
+			stateMachine,
+			state
 		} = event;
 
 		try {
 
 			const data = await this.getFullData(body);
 
-			const dispatcher = new Dispatcher(LambdaFunction, session, data, taskToken);
+			const dispatcher = new Dispatcher(LambdaFunction, session, data, taskToken, state);
 
 			dispatcher.prepare();
 
@@ -66,7 +67,8 @@ module.exports = class Handler {
 
 			return {
 				...result,
-				stateMachine
+				stateMachine,
+				...state && { state }
 			};
 
 		} catch(error) {

--- a/lib/helpers/dispatcher.js
+++ b/lib/helpers/dispatcher.js
@@ -15,7 +15,7 @@ module.exports = class Dispatcher {
 	 * @param {ApiSession} session
 	 * @param {*} data
 	 * @param {string?} taskToken The task async token in case a function is invoked as an async task of a state machine
-	 * @param {*} state
+	 * @param {object?} state The task state. Only present for tasks invoked from state machines.
 	 */
 	constructor(LambdaFunction, session, data, taskToken, state) {
 
@@ -24,7 +24,7 @@ module.exports = class Dispatcher {
 		/** @type Lambda */
 		this.lambdaFunction = new LambdaFunction();
 
-		this.validateRequest(session, data, taskToken);
+		this.validateRequest(session, data, taskToken, state);
 
 		this.session = session;
 		this.data = data;
@@ -61,7 +61,7 @@ module.exports = class Dispatcher {
 	/**
 	 * @private
 	 */
-	validateRequest(session, data, taskToken) {
+	validateRequest(session, data, taskToken, state) {
 
 		if(session && (typeof session !== 'object' || Array.isArray(session)))
 			throw new LambdaError('Invalid Session, must be an Object', LambdaError.codes.INVALID_SESSION);
@@ -83,6 +83,9 @@ module.exports = class Dispatcher {
 
 		if(typeof taskToken !== 'undefined' && typeof taskToken !== 'string')
 			throw new LambdaError('Task token must be a string if present', LambdaError.codes.INVALID_TASK_TOKEN);
+
+		if(typeof state !== 'undefined' && typeof state !== 'object')
+			throw new LambdaError('Invalid State, must be a object if present', LambdaError.codes.INVALID_STATE);
 	}
 
 	/**

--- a/lib/helpers/dispatcher.js
+++ b/lib/helpers/dispatcher.js
@@ -15,8 +15,9 @@ module.exports = class Dispatcher {
 	 * @param {ApiSession} session
 	 * @param {*} data
 	 * @param {string?} taskToken The task async token in case a function is invoked as an async task of a state machine
+	 * @param {*} state
 	 */
-	constructor(LambdaFunction, session, data, taskToken) {
+	constructor(LambdaFunction, session, data, taskToken, state) {
 
 		this.validateLambdaFunction(LambdaFunction);
 
@@ -28,6 +29,7 @@ module.exports = class Dispatcher {
 		this.session = session;
 		this.data = data;
 		this.taskToken = taskToken;
+		this.state = state;
 	}
 
 	/**
@@ -91,6 +93,7 @@ module.exports = class Dispatcher {
 		this.setSession(this.session);
 		this.setData(this.data);
 		this.setToken(this.taskToken);
+		this.setState(this.state);
 	}
 
 	setSession(session) {
@@ -103,6 +106,10 @@ module.exports = class Dispatcher {
 
 	setToken(taskToken) {
 		this.lambdaFunction.taskToken = taskToken;
+	}
+
+	setState(state) {
+		this.lambdaFunction.state = state;
 	}
 
 	/**

--- a/lib/lambda-bases/lambda.js
+++ b/lib/lambda-bases/lambda.js
@@ -7,6 +7,13 @@ const lodashPick = require('lodash/pick');
 const NANOID_LENGTH = 10;
 const nanoid = customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789', NANOID_LENGTH);
 
+/**
+ * @typedef {object} StepFunctionContext
+ * @property {string} EnteredTime ISO 8601 Date string
+ * @property {string} Name The name of the State Machine
+ * @property {number} RetryCount The current number of retry attempts of a task
+ */
+
 module.exports = class Lambda {
 
 	/**
@@ -40,7 +47,7 @@ module.exports = class Lambda {
 	}
 
 	/**
-	 * @param {*} taskToken The task token. Only present for async invoked tasks of state machines
+	 * @param {string?} [] The task token. Only present for async invoked tasks of state machines
 	 */
 	set taskToken(taskToken) {
 		/** @private */
@@ -48,14 +55,14 @@ module.exports = class Lambda {
 	}
 
 	/**
-	 * @returns {*} The task token. Only present for async invoked tasks of state machines
+	 * @returns {string?} The task token. Only present for async invoked tasks of state machines
 	 */
 	get taskToken() {
 		return this._taskToken;
 	}
 
 	/**
-	 * @param {*} state The invocation state. Only present for async invoked tasks of state machines
+	 * @param {StepFunctionContext?} state The invocation state. Only present for async invoked tasks of state machines
 	 */
 	set state(state) {
 		/** @private */
@@ -63,7 +70,7 @@ module.exports = class Lambda {
 	}
 
 	/**
-	 *  @returns {*} The invocation state. Only present for async invoked tasks of state machines
+	 *  @returns {StepFunctionContext?} The invocation state. Only present for async invoked tasks of state machines
 	*/
 	get state() {
 		return this._state;

--- a/lib/lambda-bases/lambda.js
+++ b/lib/lambda-bases/lambda.js
@@ -55,6 +55,21 @@ module.exports = class Lambda {
 	}
 
 	/**
+	 * @param {*} state The invocation state. Only present for async invoked tasks of state machines
+	 */
+	set state(state) {
+		/** @private */
+		this._state = state;
+	}
+
+	/**
+	 *  @returns {*} The invocation state. Only present for async invoked tasks of state machines
+	*/
+	get state() {
+		return this._state;
+	}
+
+	/**
 	 * @returns {boolean} Whether the invocation must have a client associated or not
 	 */
 	get mustHaveClient() {

--- a/lib/lambda-error.js
+++ b/lib/lambda-error.js
@@ -24,7 +24,8 @@ module.exports = class LambdaError extends Error {
 			INVOCATION_FAILED: 18,
 			ASSUME_ROLE_ERROR: 19,
 			NO_LOCAL_SERVICE_PORT: 20,
-			NO_ENDPOINT_PARAMS: 21
+			NO_ENDPOINT_PARAMS: 21,
+			INVALID_STATE: 22
 		};
 	}
 

--- a/lib/parallel-handler.js
+++ b/lib/parallel-handler.js
@@ -10,13 +10,16 @@ module.exports = class ParallelHandler extends Handler {
 	 * @returns {import('./handler').AWSLambdaEvent}
 	 */
 	static prepareEvent(event) {
-		return event.reduce((preparedEvent, { body, session, stateMachine }) => {
+		return event.reduce((preparedEvent, { body, session, stateMachine, state }) => {
 
 			if(session && !preparedEvent.session)
 				preparedEvent.session = session;
 
 			if(stateMachine && !preparedEvent.stateMachine)
 				preparedEvent.stateMachine = stateMachine;
+
+			if(state && !preparedEvent.state)
+				preparedEvent.state = state;
 
 			preparedEvent.body.push(body);
 

--- a/tests/handler.js
+++ b/tests/handler.js
@@ -111,6 +111,13 @@ describe('Handler', () => {
 			);
 		});
 
+		it('Should return an error message if task state is passed and it is not a object', async () => {
+			await assert.rejects(
+				() => Handler.handle(makeLambdaClass(), { state: 'bar' }),
+				new LambdaError('Invalid State, must be a object if present', LambdaError.codes.INVALID_STATE)
+			);
+		});
+
 		it('Should return an error message if Lambda Function\'s struct failed', async () => {
 
 			const structError = new TypeError('Invalid Struct');

--- a/tests/handler.js
+++ b/tests/handler.js
@@ -58,6 +58,17 @@ describe('Handler', () => {
 
 	const session = { clientCode: 'defaultClient' };
 
+	const stateMachine = {
+		Id: 'id-state-machine',
+		Name: 'state-machine-test'
+	};
+
+	const state = {
+		EnteredTime: '2019-03-26T20:14:13.192Z',
+		Name: 'Test',
+		RetryCount: 3
+	};
+
 	context('When Invalid Args is passed and default handling Validate Errors', () => {
 
 		it('Should return an error message if no Lambda Function is passed', async () => {
@@ -362,11 +373,6 @@ describe('Handler', () => {
 				contentS3Path
 			});
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
-
 			const apiSession = new ApiSession({ ...session });
 			class LambdaFunctionExample {
 
@@ -380,8 +386,8 @@ describe('Handler', () => {
 
 			assert.deepStrictEqual(await Handler.handle(
 				LambdaFunctionExample,
-				{ session, body: { contentS3Path }, stateMachine }
-			), { session: apiSession, body: { contentS3Path }, stateMachine });
+				{ session, body: { contentS3Path }, stateMachine, state }
+			), { session: apiSession, body: { contentS3Path }, stateMachine, state });
 
 			sinon.assert.calledOnceWithExactly(Lambda.getBodyFromS3, contentS3Path);
 			sinon.assert.calledOnceWithExactly(Lambda.bodyToS3Path, 'step-function-payloads', body, []);
@@ -408,11 +414,6 @@ describe('Handler', () => {
 				contentS3Path
 			});
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
-
 			const apiSession = new ApiSession({ ...session });
 			class LambdaFunctionExample {
 
@@ -426,8 +427,13 @@ describe('Handler', () => {
 
 			assert.deepStrictEqual(await Handler.handle(
 				LambdaFunctionExample,
-				{ session, body: { contentS3Path, error: { Error: 'Lambda.Unknown' } }, stateMachine }
-			), { session: apiSession, body: { contentS3Path }, stateMachine });
+				{
+					session,
+					body: { contentS3Path, error: { Error: 'Lambda.Unknown' } },
+					stateMachine,
+					state
+				}
+			), { session: apiSession, body: { contentS3Path }, stateMachine, state });
 
 			sinon.assert.calledOnceWithExactly(Lambda.getBodyFromS3, contentS3Path);
 			sinon.assert.calledOnceWithExactly(Lambda.bodyToS3Path, 'step-function-payloads', {
@@ -438,10 +444,6 @@ describe('Handler', () => {
 
 		it('Should return the same value when the payload has no session and body and the lambda is executed as a step function', async () => {
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
 			class LambdaFunctionExample {
 
 				process() {
@@ -451,16 +453,12 @@ describe('Handler', () => {
 
 			assert.deepStrictEqual(await Handler.handle(
 				LambdaFunctionExample,
-				{ stateMachine }
+				{ stateMachine, state }
 			), {});
 		});
 
 		it('Should use a default value when the payload has no body and the lambda is executed as a step function', async () => {
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
 			class LambdaFunctionExample {
 
 				process() {
@@ -472,16 +470,12 @@ describe('Handler', () => {
 
 			assert.deepStrictEqual(await Handler.handle(
 				LambdaFunctionExample,
-				{ stateMachine }
-			), { session: 'session', body: null, stateMachine });
+				{ stateMachine, state }
+			), { session: 'session', body: null, stateMachine, state });
 		});
 
 		it('Should use a default value when the payload has no sessions and the lambda is executed as a step function', async () => {
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
 			class LambdaFunctionExample {
 
 				process() {
@@ -493,8 +487,8 @@ describe('Handler', () => {
 
 			assert.deepStrictEqual(await Handler.handle(
 				LambdaFunctionExample,
-				{ stateMachine }
-			), { session: null, body: {}, stateMachine });
+				{ stateMachine, state }
+			), { session: null, body: {}, stateMachine, state });
 		});
 	});
 });

--- a/tests/lambda-bases/lambda.js
+++ b/tests/lambda-bases/lambda.js
@@ -47,6 +47,21 @@ describe('Lambda bases', () => {
 		assert.deepStrictEqual(lambda.taskToken, invocationData);
 	});
 
+	it('Should have working getter and setter for state', () => {
+
+		const invocationData = {
+			EnteredTime: '2019-03-26T20:14:13.192Z',
+			Name: 'Test',
+			RetryCount: 3
+		};
+
+		const lambda = new Lambda();
+
+		lambda.state = invocationData;
+
+		assert.deepStrictEqual(lambda.state, invocationData);
+	});
+
 	it('Should have validation getter mustHaveClient set as false by default', () => {
 		const lambda = new Lambda();
 		assert.deepStrictEqual(lambda.mustHaveClient, false);

--- a/tests/parallel-handler.js
+++ b/tests/parallel-handler.js
@@ -10,6 +10,17 @@ describe('ParallelHandler', () => {
 
 	const session = { clientCode: 'defaultClient' };
 
+	const stateMachine = {
+		Id: 'id-state-machine',
+		Name: 'state-machine-test'
+	};
+
+	const state = {
+		EnteredTime: '2019-03-26T20:14:13.192Z',
+		Name: 'Test',
+		RetryCount: 3
+	};
+
 	context('When valid Args is passed', () => {
 
 		it('Should set correct session and data', async () => {
@@ -26,14 +37,9 @@ describe('ParallelHandler', () => {
 				pets: ['Dogs', 'Frogs']
 			};
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
-
 			const event = [
-				{ body: body1, session, stateMachine },
-				{ body: body2, session, stateMachine }
+				{ body: body1, session, stateMachine, state },
+				{ body: body2, session, stateMachine, state }
 			];
 
 			const apiSession = new ApiSession({ ...session });
@@ -51,7 +57,8 @@ describe('ParallelHandler', () => {
 			assert.deepStrictEqual(await ParallelHandler.handle(LambdaFunctionExample, event), {
 				session: apiSession,
 				body: [body1, body2],
-				stateMachine
+				stateMachine,
+				state
 			});
 		});
 
@@ -99,16 +106,11 @@ describe('ParallelHandler', () => {
 				.withArgs(bodyLong2.contentS3Path)
 				.resolves(body4);
 
-			const stateMachine = {
-				id: 'id-state-machine',
-				name: 'state-machine-test'
-			};
-
 			const event = [
-				{ body: body1, session, stateMachine },
-				{ body: body2, session, stateMachine },
-				{ body: bodyLong1, session, stateMachine },
-				{ body: bodyLong2, session, stateMachine }
+				{ body: body1, session, stateMachine, state },
+				{ body: body2, session, stateMachine, state },
+				{ body: bodyLong1, session, stateMachine, state },
+				{ body: bodyLong2, session, stateMachine, state }
 			];
 
 			const apiSession = new ApiSession({ ...session });
@@ -127,7 +129,8 @@ describe('ParallelHandler', () => {
 			assert.deepStrictEqual(await ParallelHandler.handle(LambdaFunctionExample, event), {
 				session: apiSession,
 				body: [body1, body2, body3, body4],
-				stateMachine
+				stateMachine,
+				state
 			});
 		});
 	});


### PR DESCRIPTION
**Link al ticket**

[Historia](https://janiscommerce.atlassian.net/browse/JCN-467)

[Subtarea](https://janiscommerce.atlassian.net/browse/JCN-469)

**Descripción del requerimiento**

Se modificó el package [sls-helper-plugin-janis](https://github.com/jormaechea/sls-helper-plugin-janis) para que llegue un nuevo dato en el evento de las lambdas de las tasks de las state-machines(https://janiscommerce.atlassian.net/browse/JCN-466)

La property nueva es `state` y esta debe ser accesible por la lambda de la task que la utiliza.

Esto específicamente para saber si una ejecución es un retry o para saber que numero de retry es la ejecución actual.

**Descripción de la solución**

Se modificaron algunas clases donde se van pasando los datos de los eventos a los lambdas haciéndole llegar el nuevo dato de `state` y se agregaron nuevos métodos setearlos y getearlo desde la lambda.

**Changelog**

```
### Added
- Add new getter for lambda for access state-machine task state
```